### PR TITLE
Fix menu item condition to avoid empty ul

### DIFF
--- a/_includes/menu_item.html
+++ b/_includes/menu_item.html
@@ -12,7 +12,7 @@
       {% include post_list.html %}
     {% endif %}
 
-    {% if item.entries != blank %}        
+    {% if item.entries %}
       {% include menu_item.html collection=item.entries %}
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
The values of the `entries` field in `_data/menu.yml` are either a list or `false`, however it was
compared to `blank` in `_include/menu_item.html`.  As a result, some empty `<ul></ul>`s were
generated in `_site/index.html` before. Thank you. :)