### PR TITLE
Minify spaces in generated html

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,4 +25,3 @@ sass:
 plugins:
   - jekyll-feed
   - jekyll-seo-tag
-  - jekyll-tidy

--- a/_config.yml
+++ b/_config.yml
@@ -25,3 +25,4 @@ sass:
 plugins:
   - jekyll-feed
   - jekyll-seo-tag
+  - jekyll-tidy

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,8 +11,8 @@
     {%- endif -%}
   </title>
 
-  {% seo title=false %}
-  {% feed_meta %}
+  {%-seo title=false-%}
+  {%-feed_meta-%}
 
   <link rel="shortcut icon" type="image/x-icon" href="{{ site.favicon | relative_url }}" />
   <link rel="stylesheet" href="{{ "/assets/css/main.css" | relative_url }}" />

--- a/_includes/menu_item.html
+++ b/_includes/menu_item.html
@@ -1,5 +1,5 @@
 <ul>
-  {% for item in include.collection %}
+  {%-for item in include.collection-%}
     <li>
     {%- if item.url -%}
       <a href="{{ item.url }}">{{ item.title }}</a>
@@ -8,7 +8,7 @@
     {%- endif -%}
     </li>
 
-    {% if item.post_list %}
+    {%-if item.post_list-%}
       {%
         include post_list.html
           category=item.post_list.category
@@ -16,11 +16,11 @@
           show_more=item.post_list.show_more
           show_more_text=item.post_list.show_more_text
           show_more_url=item.post_list.show_more_url
-      %}
-    {% endif %}
+     -%}
+    {%-endif-%}
 
-    {% if item.entries %}
-      {% include menu_item.html collection=item.entries %}
-    {% endif %}
-  {% endfor %}
+    {%-if item.entries-%}
+      {%-include menu_item.html collection=item.entries-%}
+    {%-endif-%}
+  {%-endfor-%}
 </ul>

--- a/_includes/post_list.html
+++ b/_includes/post_list.html
@@ -1,14 +1,14 @@
-{% if include.category %}
-  {% assign posts = site.categories[include.category] %}  
-{% else %}
-  {% assign posts = site.posts %}
-{% endif %}
+{%-if include.category-%}
+  {%-assign posts = site.categories[include.category]-%}  
+{%-else-%}
+  {%-assign posts = site.posts-%}
+{%-endif-%}
 
-{% if include.limit and posts.size > include.limit %}
-  {% assign limit_exceeded = true %}
-{% else %}
-  {% assign limit_exceeded = false %}
-{% endif %}
+{%-if include.limit and posts.size > include.limit-%}
+  {%-assign limit_exceeded = true-%}
+{%-else-%}
+  {%-assign limit_exceeded = false-%}
+{%-endif-%}
 
 {%- if posts.size > 0 -%}
   <ul>

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -2,8 +2,8 @@
 layout: default
 ---
 
-{% include back_link.html %}
+{%-include back_link.html-%}
 
 <h1>{{ page.title }}</h1>
 
-{% include post_list.html category=page.which_category %}
+{%-include post_list.html category=page.which_category-%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,8 +8,8 @@
       </div>
     </main>
 
-    {% if site.goat_counter and jekyll.environment == "production" %}
-      {% include goat_counter.html %}
-    {% endif %}
+    {%-if site.goat_counter and jekyll.environment == "production"-%}
+      {%-include goat_counter.html-%}
+    {%-endif-%}
   </body>
 </html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -3,11 +3,11 @@ layout: default
 ---
 <header>
   <h1>{{ site.title }}</h1>
-  {% if site.theme_config.show_description %}
+  {%-if site.theme_config.show_description-%}
     <p>{{ site.description }}</p>
-  {% endif %}
+  {%-endif-%}
 </header>
 
-{% include menu_item.html collection=site.data.menu.entries %}
+{%-include menu_item.html collection=site.data.menu.entries-%}
 
 {{ content }}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-{% include back_link.html %}
+{%-include back_link.html-%}
 
 <h1>{{ page.title }}</h1>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-{% include back_link.html %}
+{%-include back_link.html-%}
 
 <article>
   <p class="post-meta">

--- a/no-style-please.gemspec
+++ b/no-style-please.gemspec
@@ -15,6 +15,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jekyll", "~> 3.8.7"
   spec.add_runtime_dependency "jekyll-feed", "~> 0.13.0"
   spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.6.1"
-  spec.add_runtime_dependency "jekyll-tidy", "~> 0.2.2"
 
 end

--- a/no-style-please.gemspec
+++ b/no-style-please.gemspec
@@ -15,4 +15,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jekyll", "~> 3.8.7"
   spec.add_runtime_dependency "jekyll-feed", "~> 0.13.0"
   spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.6.1"
+  spec.add_runtime_dependency "jekyll-tidy", "~> 0.2.2"
+
 end


### PR DESCRIPTION
Also mentioned in #14 the generated HTML content is all over the place, with enormous spaces.

This PR introduced whitespace control introduced in Liquid 4.0.0, and even with this there are a few whitespaces there and there.

The code looks A-okey without `jekyll-tidy` but on my website I've found that in some places there are a few whitespaces left over.

# Before

![image](https://user-images.githubusercontent.com/41646249/106931466-4be6dc00-671f-11eb-9db6-2bce7fcbc732.png)

# After

![image](https://user-images.githubusercontent.com/41646249/106931529-5c975200-671f-11eb-8ef5-f8568fcb4286.png)

<details>
<summary>This is how my website source looked with the tag fixes but without `jekyll-tidy`</summary>

<!-- leave a blank line above -->
![image](https://user-images.githubusercontent.com/41646249/106933049-23f87800-6721-11eb-992a-ff05fe76cc7b.png)
</details>





