### PR TITLE
Display index.md content above menu

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,7 @@ theme_config:
   back_home_text: ".." # customize text for homepage link in post layout
   date_format: "%Y-%m-%d" # customize how date is formatted
   show_description: false # show blog description in home page
+  show_index_content_in_top: false # show content of index.md above menu
 
 sass:
   style: :compressed

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -8,6 +8,12 @@ layout: default
   {%-endif-%}
 </header>
 
+{%-if site.theme_config.show_index_content_in_top-%}
+  {{ content }}
+{%-endif-%}
+
 {%-include menu_item.html collection=site.data.menu.entries-%}
 
-{{ content }}
+{%-unless site.theme_config.show_index_content_in_top-%}
+  {{ content }}
+{%-endunless-%}


### PR DESCRIPTION
I looked for a way to display the content of index.md above the home menu. Didn't take too long to implement a new option for it. If you like, you can pull this upstream.