### PR TITLE
Add Google Analytics 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ The `index.md` page should use layout `home`, which is the layout that displays 
 
 Another thing you can do to customize the index page is show the description of your blog between the title and the menu. To do this, just edit `_config.yml` and change `theme_config.show_description` to `true`.
 
+### Enabling Google Analytics
+
+To enable Google Analytics, add the following lines to your Jekyll site:
+
+```yaml
+  google_analytics: G-XXXXXXXX
+```
+
+Google Analytics will only appear in production, i.e., `JEKYLL_ENV=production`
+
 ### Pro tips
 
 #### Dark mode for images

--- a/_includes/google_analytics.html
+++ b/_includes/google_analytics.html
@@ -1,0 +1,9 @@
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ site.google_analytics }}');
+</script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,6 +13,10 @@
 
   {%-seo title=false-%}
   {%-feed_meta-%}
+  
+  {%- if jekyll.environment == 'production' and site.google_analytics -%}
+    {%- include google_analytics.html -%}
+  {%- endif -%}
 
   <link rel="shortcut icon" type="image/x-icon" href="{{ site.favicon | relative_url }}" />
   <link rel="stylesheet" href="{{ "/assets/css/main.css" | relative_url }}" />


### PR DESCRIPTION
Hi. Thank you for creating this awesome theme. I really like the simplicity of it. I use it for my portfolio website.

I've added Google Analytics 4 support. It's basicaly a copy-paste from official "minima" theme. So there shouldn't be any bugs or issues I guess.
And it works the exactly same way as in official documentation:
> ### Enabling Google Analytics
>
>To enable Google Analytics, add the following lines to your Jekyll site:
>
>```yaml
>  google_analytics: UA-NNNNNNNN-N
>```
>
>Google Analytics will only appear in production, i.e., `JEKYLL_ENV=production`

- Fixes #63 