### PR TITLE
no-style-please.scss: do not invert emoji in darkmode

### DIFF
--- a/_sass/no-style-please.scss
+++ b/_sass/no-style-please.scss
@@ -6,6 +6,7 @@
 
     &.ioda { filter: invert(0); }
   }
+.emoji { filter: invert(1); }
 }
 
 body[a="dark"] { @include dark-appearance; }


### PR DESCRIPTION
Actually reinverts it after being inverted, but that's beside the point

Fixes #28