### PR TITLE
fixed Gemfile for ruby 3.3.5 removing LoadError for webrick

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "kramdown-parser-gfm"
+gem "webrick"
 
 gemspec


### PR DESCRIPTION
I ran into this error executing `bundle exec jekyll serve`:

```
/opt/homebrew/Cellar/ruby/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `require': cannot load such file -- webrick (LoadError)
```

Fixed it by adding `gem "webrick"` to Gemfile