### PR TITLE
Update no-style-please.gemspec

### DIFF
--- a/no-style-please.gemspec
+++ b/no-style-please.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "jekyll", "~> 3.9.0"
   spec.add_runtime_dependency "jekyll-feed", "~> 0.15.1"
-  spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.7.1"
+  spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.8.0"
 
 end


### PR DESCRIPTION
### PR Description

- Fixes #93.

#### **Summary**:
This PR updates the dependency of `jekyll-seo-tag` in the `no-style-please` gem to be compatible with GitHub Pages >= 228 and Liquid 4.0.4. The update resolves the version conflict between `jekyll-seo-tag` 2.7.1 (required by `no-style-please`) and `jekyll-seo-tag` 2.8.0 (required by GitHub Pages >= 228).  
This change ensures compatibility with Liquid 4.0.4 and fixes a critical [bug](https://github.com/jekyll/jekyll/issues/9233) preventing the site from running correctly when using Liquid 4.0.3.

#### **Changes**:
- Updated the `jekyll-seo-tag` dependency in the `no-style-please` gemspec file from `~> 2.7.1` to `~> 2.8.0`.
- This change aligns the `no-style-please` gem with the newer `jekyll-seo-tag` version, which is required for compatibility with Liquid 4.0.4 and GitHub Pages >= 228.

#### **Reasoning**:
- The [bug in Liquid 4.0.3](https://github.com/jekyll/jekyll/issues/9233) is critical and prevents the site from running correctly. This fix updates `no-style-please` to work with the latest versions of the necessary dependencies.
- `GitHub Pages >= 228` is required for compatibility with Liquid 4.0.4, which is necessary to fix the mentioned bug.  
However, `no-style-please` depends on an older version of `jekyll-seo-tag`, which was incompatible with the newer version of GitHub Pages.

#### **Impact**:
- This change ensures that `no-style-please` works seamlessly with GitHub Pages >= 228 and Liquid 4.0.4.
- It resolves the version conflict, enabling the website to run without errors related to the Liquid bug.