### PR TITLE
Fix plugin jekyll-seo-tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,9 +11,7 @@
     {%- endif -%}
   </title>
 
-  {% comment %}
   {%-seo title=false-%}
-  {% endcomment %}
   {%-feed_meta-%}
 
   <link rel="shortcut icon" type="image/x-icon" href="{{ site.favicon | relative_url }}" />


### PR DESCRIPTION
Hi there,

I am back with another pull request. Recently I realized that the plugin jekyll-seo-tag was not properly inserting its SEO tags on my personal website using this theme. I traced the issue back to commit 5563cd9 by yagarea on 02.03.2024. In this commit, they edited `_includes/head.html` by enclosing the `{% seo %}` line with a `{% comment %}`. The commit message says this was done "because [jekyll-seo-tag] does not escape strings". However, this current solution completely breaks the functionality of the jekyll-seo-tag plugin.

I have attached a commit which removes the comment lines and fixes this issue.

Best regards, Luuk